### PR TITLE
Instead of calling the constants require files

### DIFF
--- a/app/processes/imap_client.rb
+++ b/app/processes/imap_client.rb
@@ -2,6 +2,8 @@ class ImapClient
   VERSION="1.0.0"
 end
 
+require 'imap_daemon_heartbeat'
+require 'call_new_mail_webhook'
 require 'imap_client/rendezvous_hash'
 require 'imap_client/maybe'
 require 'imap_client/process_uid'

--- a/app/processes/imap_client/daemon.rb
+++ b/app/processes/imap_client/daemon.rb
@@ -57,7 +57,6 @@ class ImapClient::Daemon
 
   def run
     trap_signals
-    force_class_loading
     maybe_start_profiling
 
     # If stress testing, start a log.
@@ -111,16 +110,6 @@ class ImapClient::Daemon
 
 
   private
-
-
-  def force_class_loading
-    # Force ImapDaemonHeartbeat to load before we create any
-    # threads. This fixes a "Circular dependency detected while
-    # autoloading constant ImapDaemonHeartbeat" error.
-    ImapDaemonHeartbeat
-    CallNewMailWebhook
-    self.error_counts = {}
-  end
 
   def start_heartbeat_thread
     self.heartbeat_thread = Thread.new do


### PR DESCRIPTION
@rustyio I am not sure what was the error you were getting, and when it happened, but this makes more sense to me. Instead of calling the constants in a method, we just require the files.