### PR TITLE
Remove double quote in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Log in as the default user: "admin@example.com" / "password"
 
 Run this once:
 
-    RAILS_ENV=production rake db:setup db:seed"
+    RAILS_ENV=production rake db:setup db:seed
 
 Then start the server:
 


### PR DESCRIPTION
Just a tiny typo when using this Rake command.